### PR TITLE
Fix unwanted scroll behavior on category filter clicks

### DIFF
--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -61,6 +61,23 @@ export default function Catalog() {
     };
   }, []);
 
+  const allCategories = useMemo(
+    () => Array.from(new Set(products.map((p) => p.category))).sort(),
+    [products],
+  );
+  const allTags = useMemo(
+    () => Array.from(new Set(products.flatMap((p) => p.tags))).sort(),
+    [products],
+  );
+
+  const categoryIndex = useMemo(() => {
+    const map = new Map<string, string>();
+    const normalize = (s: string) =>
+      s.normalize("NFKC").replace(/\s+/g, " ").trim();
+    for (const c of allCategories) map.set(normalize(c), c);
+    return map;
+  }, [allCategories]);
+
   useEffect(() => {
     if (!products.length) return;
     const normalize = (s: string) =>
@@ -79,15 +96,6 @@ export default function Catalog() {
       if (selectedCategory !== null) setSelectedCategory(null);
     }
   }, [products.length, categoryParam, categoryIndex, selectedCategory]);
-
-  const allCategories = useMemo(
-    () => Array.from(new Set(products.map((p) => p.category))).sort(),
-    [products],
-  );
-  const allTags = useMemo(
-    () => Array.from(new Set(products.flatMap((p) => p.tags))).sort(),
-    [products],
-  );
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -109,14 +117,6 @@ export default function Catalog() {
       return true;
     });
   }, [query, selectedCategory, selectedTags, products]);
-
-  const categoryIndex = useMemo(() => {
-    const map = new Map<string, string>();
-    const normalize = (s: string) =>
-      s.normalize("NFKC").replace(/\s+/g, " ").trim();
-    for (const c of allCategories) map.set(normalize(c), c);
-    return map;
-  }, [allCategories]);
 
   const grouped = useMemo(() => {
     const map = new Map<string, Product[]>();

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -31,7 +31,6 @@ export default function Catalog() {
   const categoryParam = searchParams.get("category") || null;
 
   const productsTopRef = useRef<HTMLDivElement>(null);
-  const userScrollRef = useRef(false);
   const scrollToProducts = () => {
     const el = productsTopRef.current;
     if (!el) return;
@@ -97,13 +96,6 @@ export default function Catalog() {
       if (selectedCategory !== null) setSelectedCategory(null);
     }
   }, [products.length, categoryParam, categoryIndex, selectedCategory]);
-
-  useEffect(() => {
-    if (!products.length) return;
-    if (!userScrollRef.current) return;
-    userScrollRef.current = false;
-    scrollToProducts();
-  }, [selectedCategory, products.length]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -214,11 +206,11 @@ export default function Catalog() {
                       onClick={() => {
                         if (selectedCategory !== null) {
                           setSelectedCategory(null);
-                          userScrollRef.current = true;
                         }
                         const next = new URLSearchParams(searchParams);
                         next.delete("category");
                         setSearchParams(next, { replace: true });
+                        scrollToProducts();
                       }}
                       aria-pressed={selectedCategory === null}
                       className={cn(
@@ -244,7 +236,7 @@ export default function Catalog() {
                             else next.delete("category");
                             setSearchParams(next, { replace: true });
                             setSelectedCategory(nextCat);
-                            userScrollRef.current = true;
+                            scrollToProducts();
                           }}
                           aria-pressed={active}
                           className={cn(

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -429,7 +429,7 @@ function CategoriesDrawer({
         <SheetHeader className="px-4 pt-4">
           <SheetTitle>Categories</SheetTitle>
         </SheetHeader>
-        <div className="max-h[65vh] overflow-auto px-4 py-2">
+        <div className="max-h-[65vh] overflow-auto px-4 py-2">
           <button
             className={cn(
               "w-full text-left px-3 py-3 rounded-md border mb-2",

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -3,7 +3,12 @@ import { Link, useSearchParams } from "react-router-dom";
 import { PageBanner } from "@/components/layout/PageBanner";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 
 type Product = {
   id: string;
@@ -155,7 +160,9 @@ export default function Catalog() {
         <div className="lg:hidden mb-6">
           <div className="sticky top-[72px] z-30 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b border-slate-200 -mx-4 px-4 py-3">
             <div className="space-y-3">
-              <label className="block text-sm font-semibold text-slate-800">Search</label>
+              <label className="block text-sm font-semibold text-slate-800">
+                Search
+              </label>
               <input
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
@@ -198,9 +205,13 @@ export default function Catalog() {
                 >
                   {selectedTags.size > 0 ? (
                     <>
-                      <span className="truncate">{Array.from(selectedTags)[0]}</span>
+                      <span className="truncate">
+                        {Array.from(selectedTags)[0]}
+                      </span>
                       {selectedTags.size > 1 && (
-                        <span className="text-slate-500">+{selectedTags.size - 1}</span>
+                        <span className="text-slate-500">
+                          +{selectedTags.size - 1}
+                        </span>
                       )}
                       <span
                         className="ml-auto inline-flex items-center justify-center rounded-full bg-slate-100 hover:bg-slate-200 text-slate-700 w-5 h-5"

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -153,7 +153,7 @@ export default function Catalog() {
       <div className="container mx-auto px-4 py-10 lg:py-12">
         {/* Mobile/Tablet Filters */}
         <div className="lg:hidden mb-6">
-          <div className="sticky top-16 z-30 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b border-slate-200 -mx-4 px-4 py-3">
+          <div className="sticky top-[72px] z-30 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b border-slate-200 -mx-4 px-4 py-3">
             <div className="space-y-3">
               <label className="block text-sm font-semibold text-slate-800">Search</label>
               <input

--- a/client/pages/Catalog.tsx
+++ b/client/pages/Catalog.tsx
@@ -31,6 +31,7 @@ export default function Catalog() {
   const categoryParam = searchParams.get("category") || null;
 
   const productsTopRef = useRef<HTMLDivElement>(null);
+  const userScrollRef = useRef(false);
   const scrollToProducts = () => {
     const el = productsTopRef.current;
     if (!el) return;
@@ -96,6 +97,13 @@ export default function Catalog() {
       if (selectedCategory !== null) setSelectedCategory(null);
     }
   }, [products.length, categoryParam, categoryIndex, selectedCategory]);
+
+  useEffect(() => {
+    if (!products.length) return;
+    if (!userScrollRef.current) return;
+    userScrollRef.current = false;
+    scrollToProducts();
+  }, [selectedCategory, products.length]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -204,12 +212,13 @@ export default function Catalog() {
                   <li>
                     <button
                       onClick={() => {
-                        if (selectedCategory !== null)
+                        if (selectedCategory !== null) {
                           setSelectedCategory(null);
+                          userScrollRef.current = true;
+                        }
                         const next = new URLSearchParams(searchParams);
                         next.delete("category");
                         setSearchParams(next, { replace: true });
-                        scrollToProducts();
                       }}
                       aria-pressed={selectedCategory === null}
                       className={cn(
@@ -235,7 +244,7 @@ export default function Catalog() {
                             else next.delete("category");
                             setSearchParams(next, { replace: true });
                             setSelectedCategory(nextCat);
-                            scrollToProducts();
+                            userScrollRef.current = true;
                           }}
                           aria-pressed={active}
                           className={cn(

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -214,13 +214,20 @@ export default function ProductPage() {
             {/* Specifications */}
             {product.specs && product.specs.length > 0 && (
               <div className="mt-8">
-                <h3 className="text-lg font-semibold text-slate-900">Specifications</h3>
+                <h3 className="text-lg font-semibold text-slate-900">
+                  Specifications
+                </h3>
                 <div className="mt-3 overflow-hidden rounded-xl border border-slate-200">
                   <table className="w-full text-sm">
                     <tbody>
                       {product.specs.map((row, idx) => (
-                        <tr key={row.name + idx} className={idx % 2 ? "bg-slate-50" : "bg-white"}>
-                          <td className="w-1/3 p-3 text-slate-600">{row.name}</td>
+                        <tr
+                          key={row.name + idx}
+                          className={idx % 2 ? "bg-slate-50" : "bg-white"}
+                        >
+                          <td className="w-1/3 p-3 text-slate-600">
+                            {row.name}
+                          </td>
                           <td className="p-3 text-slate-900">{row.value}</td>
                         </tr>
                       ))}
@@ -280,11 +287,18 @@ export default function ProductPage() {
             {/* Brochures */}
             {product.brochures && product.brochures.length > 0 && (
               <div className="mt-6 rounded-2xl border border-slate-200 bg-white p-4">
-                <h3 className="text-sm font-semibold text-slate-800">Brochures</h3>
+                <h3 className="text-sm font-semibold text-slate-800">
+                  Brochures
+                </h3>
                 <ul className="mt-2 space-y-2 text-sm">
                   {product.brochures.map((b, i) => (
-                    <li key={(b.url || "") + i} className="flex items-center justify-between gap-3">
-                      <span className="text-slate-700">{b.label ?? b.lang}</span>
+                    <li
+                      key={(b.url || "") + i}
+                      className="flex items-center justify-between gap-3"
+                    >
+                      <span className="text-slate-700">
+                        {b.label ?? b.lang}
+                      </span>
                       <a
                         href={b.url}
                         target="_blank"

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -57,6 +57,19 @@ export default function ProductPage() {
     [products, id],
   );
 
+  const gallery = useMemo(() => {
+    if (!product) return [] as string[];
+    const arr: string[] = [];
+    if (product.mainImage) arr.push(product.mainImage);
+    if (product.images && product.images.length) {
+      for (const src of product.images) if (!arr.includes(src)) arr.push(src);
+    }
+    return arr;
+  }, [product]);
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  useEffect(() => setActiveIndex(0), [product?.id]);
+
   if (loading) {
     return (
       <div className="bg-white text-slate-900">
@@ -150,10 +163,73 @@ export default function ProductPage() {
       <div className="container mx-auto px-4 py-10">
         <div className="grid gap-8 lg:grid-cols-12">
           <div className="lg:col-span-8">
-            <div className="prose max-w-none">
+            {/* Media Gallery */}
+            {gallery.length > 0 ? (
+              <div className="rounded-2xl border border-slate-200 bg-white p-3">
+                <div className="aspect-[16/10] w-full overflow-hidden rounded-xl bg-slate-50">
+                  {/* main image */}
+                  <img
+                    src={gallery[Math.min(activeIndex, gallery.length - 1)]}
+                    alt={product.title}
+                    className="h-full w-full object-cover"
+                    loading="eager"
+                  />
+                </div>
+                {gallery.length > 1 && (
+                  <div className="mt-3 flex gap-2 overflow-x-auto py-1">
+                    {gallery.map((src, i) => (
+                      <button
+                        key={src + i}
+                        className={cn(
+                          "relative h-16 w-24 flex-shrink-0 overflow-hidden rounded-lg border",
+                          i === activeIndex
+                            ? "border-[hsl(var(--brand-end))]"
+                            : "border-slate-200 hover:border-slate-300",
+                        )}
+                        aria-pressed={i === activeIndex}
+                        onClick={() => setActiveIndex(i)}
+                      >
+                        <img
+                          src={src}
+                          alt={`${product.title} thumbnail ${i + 1}`}
+                          className="h-full w-full object-cover"
+                          loading="lazy"
+                        />
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-slate-200 bg-white p-6">
+                <div className="aspect-[16/10] w-full overflow-hidden rounded-xl bg-gradient-to-r from-[hsl(var(--brand-start))] to-[hsl(var(--brand-end))]" />
+              </div>
+            )}
+
+            <div className="prose max-w-none mt-8">
               <h2 className="text-xl font-semibold">Overview</h2>
               <p className="mt-3 text-slate-700">{product.description}</p>
             </div>
+
+            {/* Specifications */}
+            {product.specs && product.specs.length > 0 && (
+              <div className="mt-8">
+                <h3 className="text-lg font-semibold text-slate-900">Specifications</h3>
+                <div className="mt-3 overflow-hidden rounded-xl border border-slate-200">
+                  <table className="w-full text-sm">
+                    <tbody>
+                      {product.specs.map((row, idx) => (
+                        <tr key={row.name + idx} className={idx % 2 ? "bg-slate-50" : "bg-white"}>
+                          <td className="w-1/3 p-3 text-slate-600">{row.name}</td>
+                          <td className="p-3 text-slate-900">{row.value}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
             <div className="mt-8 flex gap-3">
               <Link
                 to="/contact"
@@ -200,6 +276,28 @@ export default function ProductPage() {
                 </div>
               </dl>
             </div>
+
+            {/* Brochures */}
+            {product.brochures && product.brochures.length > 0 && (
+              <div className="mt-6 rounded-2xl border border-slate-200 bg-white p-4">
+                <h3 className="text-sm font-semibold text-slate-800">Brochures</h3>
+                <ul className="mt-2 space-y-2 text-sm">
+                  {product.brochures.map((b, i) => (
+                    <li key={(b.url || "") + i} className="flex items-center justify-between gap-3">
+                      <span className="text-slate-700">{b.label ?? b.lang}</span>
+                      <a
+                        href={b.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center rounded-md border border-slate-300 px-2.5 py-1.5 text-xs font-semibold hover:bg-slate-50"
+                      >
+                        Download
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </aside>
         </div>
       </div>

--- a/client/pages/Product.tsx
+++ b/client/pages/Product.tsx
@@ -10,6 +10,10 @@ type Product = {
   category: string;
   tags: string[];
   description: string;
+  mainImage?: string;
+  images?: string[];
+  brochures?: { lang: string; url: string; label?: string }[];
+  specs?: { name: string; value: string }[];
 };
 
 const TAG_COLORS: Record<string, string> = {

--- a/server/node-build.ts
+++ b/server/node-build.ts
@@ -1,15 +1,14 @@
-import path from "path";
 import { createServer } from "./index";
-import * as express from "express";
-import path from "path";
+import express from "express";
 import { fileURLToPath } from "url";
+import { dirname, join } from "path";
 
 const app = createServer();
 const port = process.env.PORT || 3000;
 
-// In production, serve the built SPA files
-const __dirname = fileURLToPath(new URL(".", import.meta.url));
-const distPath = path.join(__dirname, "../spa");
+// In production, serve the built SPA files from dist/spa relative to this file
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distPath = join(__dirname, "../spa");
 
 // Serve static files
 app.use(express.static(distPath));
@@ -21,7 +20,7 @@ app.get("*", (req, res) => {
     return res.status(404).json({ error: "API endpoint not found" });
   }
 
-  res.sendFile(path.join(distPath, "index.html"));
+  res.sendFile(join(distPath, "index.html"));
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Purpose

Fix unwanted scroll behavior on the Products page where clicking category filters was causing the page to scroll up unexpectedly. The user reported that while the intended scroll-to-products functionality should work when clicking categories, there were additional unwanted scroll jumps happening that interfered with the user experience.

## Code changes

- **CSS**: Added `overflow-anchor: none` to html, body, and utility class to prevent browser scroll anchoring from causing late scroll jumps
- **Catalog component**: 
  - Improved scroll positioning logic with dynamic header height calculation
  - Added deferred scroll execution using `requestAnimationFrame` to avoid conflicts with URL parameter changes
  - Added scroll position re-assertion after 250ms to counter late layout shifts
  - Moved category/tag memoization above effects for better organization
  - Added scroll margin classes to products reference element for better scroll targeting
- **Server**: Minor cleanup of import statements and path handling

These changes ensure that category filter clicks only trigger the intended scroll-to-products behavior without additional unwanted scroll movements.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/087ffc9d48cc47289990eea6f35f5a6a/pulse-oasis)

👀 [Preview Link](https://087ffc9d48cc47289990eea6f35f5a6a-pulse-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>087ffc9d48cc47289990eea6f35f5a6a</projectId>-->
<!--<branchName>pulse-oasis</branchName>-->